### PR TITLE
Fix MugDiffusion.zip download error

### DIFF
--- a/Mug_Diffusion.ipynb
+++ b/Mug_Diffusion.ipynb
@@ -48,7 +48,7 @@
         "!git clone https://github.com/Keytoyze/Mug-Diffusion.git ./MG\n",
         "!cp -rf ./MG/* .\n",
         "!aria2c --summary-interval=5 -x 3 --allow-overwrite=true -Z \\\n",
-        "   https://dl2.hiosu.com/d/kuit/MugDiffusion.zip\n",
+        "   https://dl2.hiosu.com/d/osu!ranked%E8%B0%B1%E5%8C%85%E8%BD%BD%E7%82%B9/osu!ranked/MugDiffusion/MugDiffusion.zip?sign=T83huCrq4iD_ainFBduDDk_glmrA3r5HVxQhWogmKxU=:1705655825\n",
         "!unzip MugDiffusion.zip \"*/models/ckpt/*\" -d . && rm MugDiffusion.zip\n",
         "!cp -rf MugDiffusion/* .\n",
         "\n"

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Run MuG Diffusion on Google Colab!
 
 [Original Project: Keytoyze/Mug-Diffusion](https://github.com/Keytoyze/Mug-Diffusion)
 
-<a href="https://colab.research.google.com/github/immccn123/Mug-Diffusion-Colab/blob/main/Mug_Diffusion.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+<a href="https://colab.research.google.com/github/ARM64V7A/Mug-Diffusion-Colab/blob/main/Mug_Diffusion.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>


### PR DESCRIPTION
The author has changed the path of the file, so the original link cannot be downloaded.